### PR TITLE
Backport to 1.19.4

### DIFF
--- a/.architectury-transformer/debug.log
+++ b/.architectury-transformer/debug.log
@@ -1,1 +1,1 @@
-[Architectury Transformer DEBUG] Closing File Systems for E:\Storage10\Users\UNKNOWN\ArchitecturyModding\labelsMULTI\common\build\libs\labels-1.19-1.13.jar
+[Architectury Transformer DEBUG] Closed File Systems for C:\Users\mmwoj\OneDrive\Desktop\mods\ExperiencedCrops\common\build\libs\experienced_crops-1.20.1-1.1.0.jar

--- a/build.gradle
+++ b/build.gradle
@@ -18,16 +18,11 @@ subprojects {
         minecraft "com.mojang:minecraft:${rootProject.minecraft_version}"
         // The following line declares the mojmap mappings, you may use other mappings as well
         mappings loom.layered() {
-            // officialMojangMappings()
-            // parchment("org.parchmentmc.data:parchment-${rootProject.parchment_version}")
-//            it.addLayer(quiltMappings.mappings("org.quiltmc:quilt-mappings:${rootProject.quilt_version}"))
             it.parchment("org.parchmentmc.data:parchment-${rootProject.parchment_version}")
             it.officialMojangMappings {
                 setNameSyntheticMembers(false)
             }
         }
-        // The following line declares the yarn mappings you may select this one as well.
-        // mappings "net.fabricmc:yarn:1.19+build.4:v2"
     }
 }
 

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -7,14 +7,7 @@ loom {
 }
 
 dependencies {
-    // We depend on fabric loader here to use the fabric @Environment annotations and get the mixin dependencies
-    // Do NOT use other classes from fabric loader
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
-
-    //implementation fileTree(dir: 'mods', include: '*.jar')
-
-    modImplementation("curse.maven:selene-499980:4654718")
-    //modImplementation("curse.maven:selene-499980:3859470")
 }
 
 publishing {

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 
     //implementation fileTree(dir: 'mods', include: '*.jar')
 
-    modImplementation("net.mehvahdjukaar:moonlight:${project.moonlight_version}")
+    modImplementation("curse.maven:selene-499980:4654718")
     //modImplementation("curse.maven:selene-499980:3859470")
 }
 

--- a/common/src/main/java/com/ordana/experienced_crops/ModTags.java
+++ b/common/src/main/java/com/ordana/experienced_crops/ModTags.java
@@ -1,6 +1,6 @@
 package com.ordana.experienced_crops;
 
-import net.minecraft.core.Registry;
+import net.minecraft.core.registries.Registries;
 import net.minecraft.tags.TagKey;
 import net.minecraft.world.level.block.Block;
 
@@ -8,6 +8,6 @@ public class ModTags {
     public static final TagKey<Block> CROPS_WITHOUT_EXP = registerBlockTag("crops_without_exp");
 
     private static TagKey<Block> registerBlockTag(String id) {
-        return TagKey.create(Registry.BLOCK_REGISTRY, ExperiencedCrops.res(id));
+        return TagKey.create(Registries.BLOCK, ExperiencedCrops.res(id));
     }
 }

--- a/common/src/main/resources/assets/experienced_crops/lang/en_us.json
+++ b/common/src/main/resources/assets/experienced_crops/lang/en_us.json
@@ -1,5 +1,0 @@
-{
-  "entity.experienced_crops.mod_entity": "Mod Entity",
-  "item.experienced_crops.mod_item": "Mod Item",
-  "block.experienced_crops.mod_block": "Mod Block"
-}

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -23,20 +23,7 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     modApi "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}"
 
-    //modImplementation("net.mehvahdjukaar:moonlight-fabric:${rootProject.moonlight_version}")
-    //modImplementation("net.mehvahdjukaar:moonlight-fabric:${rootProject.moonlight_version}")
-    modImplementation("curse.maven:selene-499980:4059670")
-
-    //modImplementation(include("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_version}")) {
-    //    exclude group: 'net.fabricmc.fabric-api'
-    //}
-    modImplementation("curse.maven:yacl-667299:3987709")
-
-    // modCompileOnly("curse.maven:modmenu-308702:3920481")
-
-    modImplementation("curse.maven:modmenu-308702:3920481") {
-        exclude module: "fabric-api"
-    }
+    modImplementation("curse.maven:selene-499980:4654718")
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -23,19 +23,15 @@ dependencies {
     modImplementation "net.fabricmc:fabric-loader:${rootProject.fabric_loader_version}"
     modApi "net.fabricmc.fabric-api:fabric-api:${rootProject.fabric_api_version}"
 
-    modImplementation("curse.maven:selene-499980:4654718")
-
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionFabric")) { transitive false }
 }
 
 processResources {
-
     inputs.property "version", project.version
-    inputs.property "mod_id", rootProject.mod_id
 
     filesMatching("fabric.mod.json") {
-        expand "version": project.version, "mod_id": rootProject.mod_id, "moonlight_version": rootProject.moonlight_version
+        expand "version": project.version
     }
 }
 

--- a/fabric/src/main/java/com/ordana/experienced_crops/fabric/ExperiencedCropsFabric.java
+++ b/fabric/src/main/java/com/ordana/experienced_crops/fabric/ExperiencedCropsFabric.java
@@ -7,8 +7,6 @@ public class ExperiencedCropsFabric implements ModInitializer {
 
     @Override
     public void onInitialize() {
-
         ExperiencedCrops.commonInit();
-
     }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -25,6 +25,6 @@
   ],
   "depends": {
     "fabric": "*",
-    "minecraft": ">=1.20"
+    "minecraft": "1.19.4"
   }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -17,9 +17,6 @@
   "entrypoints": {
     "main": [
       "com.ordana.experienced_crops.fabric.ExperiencedCropsFabric"
-    ],
-    "modmenu": [
-      "com.ordana.experienced_crops.integration.fabric.ModMenuCompat"
     ]
   },
   "mixins": [
@@ -28,7 +25,6 @@
   ],
   "depends": {
     "fabric": "*",
-    "minecraft": ">=1.20",
-    "moonlight": ">=1.20-2.7.0"
+    "minecraft": ">=1.20"
   }
 }

--- a/fabric/src/main/resources/fabric.mod.json
+++ b/fabric/src/main/resources/fabric.mod.json
@@ -28,7 +28,7 @@
   ],
   "depends": {
     "fabric": "*",
-    "minecraft": ">=1.19.2",
-    "moonlight": ">=1.19.2-2.0.35"
+    "minecraft": ">=1.20",
+    "moonlight": ">=1.20-2.7.0"
   }
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -32,12 +32,9 @@ configurations {
 processResources {
 
     inputs.property "version", project.version
-    inputs.property "moonlight_version", rootProject.moonlight_version
-    //inputs.property "mod_name": project.getArchivesBaseName()
 
     filesMatching("META-INF/mods.toml") {
-        expand "version": project.version, "moonlight_version": rootProject.moonlight_version
-        expand "mod_name": project.getArchivesBaseName()
+        expand "version": project.version
     }
 }
 
@@ -140,8 +137,6 @@ repositories{
 
 dependencies {
     forge "net.minecraftforge:forge:${rootProject.forge_version}"
-    // Remove the next line if you don't want to depend on the API
-    // modApi "dev.architectury:architectury-forge:${rootProject.architectury_version}"
 
     common(project(path: ":common", configuration: "namedElements")) { transitive false }
     shadowCommon(project(path: ":common", configuration: "transformProductionForge")) { transitive = false }
@@ -151,12 +146,5 @@ dependencies {
         modImplementation(include(it))
     }
 
-
-
     implementation 'org.jetbrains:annotations:22.0.0'
-
-    modImplementation("curse.maven:selene-499980:4654070")
-    //modImplementation("net.mehvahdjukaar:moonlight-forge:${project.moonlight_version}")
-    //modImplementation ("curse.maven:jei-238222:3884337")
-    //modImplementation ("curse.maven:configured-457570:4011355")
 }

--- a/forge/build.gradle
+++ b/forge/build.gradle
@@ -155,7 +155,7 @@ dependencies {
 
     implementation 'org.jetbrains:annotations:22.0.0'
 
-    modImplementation("curse.maven:selene-499980:4040434")
+    modImplementation("curse.maven:selene-499980:4654070")
     //modImplementation("net.mehvahdjukaar:moonlight-forge:${project.moonlight_version}")
     //modImplementation ("curse.maven:jei-238222:3884337")
     //modImplementation ("curse.maven:configured-457570:4011355")

--- a/forge/src/main/java/com/ordana/experienced_crops/forge/ExperiencedCropsForge.java
+++ b/forge/src/main/java/com/ordana/experienced_crops/forge/ExperiencedCropsForge.java
@@ -8,11 +8,6 @@ public class ExperiencedCropsForge {
 
     public ExperiencedCropsForge() {
         ExperiencedCrops.commonInit();
-        /*
-        if (PlatformHelper.getEnv().isClient()) {
-            ModidClient.init();
-        }
-        */
     }
 }
 

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -31,6 +31,6 @@ Obtain xp orbs from fully grown crops!
 [[dependencies.experienced_crops]]
     modId="minecraft"
     mandatory=true
-    versionRange="[1.20,1.21)"
+    versionRange="[1.19.4]"
     ordering="NONE"
     side="BOTH"

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -1,49 +1,36 @@
 
-modLoader="javafml" #mandatory
+modLoader="javafml"
 
-loaderVersion="[40,)" #mandatory This is typically bumped every Minecraft version by Forge. See our download page for lists of versions.
+loaderVersion="[40,)"
 
 license="LGPLv3"
 
-[[mods]] #mandatory
+[[mods]]
 
-modId="experienced_crops" #mandatory
+modId="experienced_crops"
 
 version = "${version}"
 
-displayName="Experienced Crops" #mandatory
+displayName="Experienced Crops"
 
-logoFile="icon.png" #optional
+logoFile="icon.png"
 
-authors="Ordana" #optional
+authors="Ordana"
 
 description='''
 Obtain xp orbs from fully grown crops!
 '''
 
-[[dependencies.experienced_crops]] #optional
-    # the modid of the dependency
-    modId="forge" #mandatory
-
-    mandatory=true #mandatory
-
-    versionRange="[40,)" #mandatory
-
+[[dependencies.experienced_crops]]
+    modId="forge"
+    mandatory=true
+    versionRange="[40,)"
     ordering="NONE"
     side="BOTH"
-# Here's another dependency
+    
 [[dependencies.experienced_crops]]
     modId="minecraft"
     mandatory=true
-# This version range declares a minimum of the current minecraft version up to but not including the next major version
     versionRange="[1.20,1.21)"
-    ordering="NONE"
-    side="BOTH"
-
-[[dependencies.experienced_crops]]
-
-    modId="moonlight"
-    mandatory=true
-    versionRange="[1.20-2.7.0,]"
     ordering="NONE"
     side="BOTH"

--- a/forge/src/main/resources/META-INF/mods.toml
+++ b/forge/src/main/resources/META-INF/mods.toml
@@ -36,7 +36,7 @@ Obtain xp orbs from fully grown crops!
     modId="minecraft"
     mandatory=true
 # This version range declares a minimum of the current minecraft version up to but not including the next major version
-    versionRange="[1.19.2,1.20)"
+    versionRange="[1.20,1.21)"
     ordering="NONE"
     side="BOTH"
 
@@ -44,6 +44,6 @@ Obtain xp orbs from fully grown crops!
 
     modId="moonlight"
     mandatory=true
-    versionRange="[1.19.2-2.0.35,]"
-    ordering="AFTER"
+    versionRange="[1.20-2.7.0,]"
+    ordering="NONE"
     side="BOTH"

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,11 +9,9 @@ mod_version=1.19.4-1.1.1
 maven_group=com.ordana.experienced_crops
 
 parchment_version = 1.19.4:2023.06.26
-# To confirm
 quilt_version = 1.19.4+build.10
 
 fabric_loader_version=0.14.22
 fabric_api_version=0.87.0+1.19.4
 
-# To confirm
 forge_version=1.19.4-45.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,25 +2,18 @@ org.gradle.jvmargs=-Xmx4096M
 
 mod_id=experienced_crops
 
-minecraft_version=1.20.1
+minecraft_version=1.19.4
 enabled_platforms=fabric,forge
 
-mod_version=1.20.1-1.1.1
+mod_version=1.19.4-1.1.1
 maven_group=com.ordana.experienced_crops
 
-parchment_version = 1.20.1:2023.07.09
-quilt_version = 0.20.0-beta.4
+parchment_version = 1.19.4:2023.06.26
+# To confirm
+quilt_version = 1.19.4+build.10
 
 fabric_loader_version=0.14.22
-fabric_api_version=0.86.0+1.20.1
+fabric_api_version=0.87.0+1.19.4
 
-forge_version=1.20.1-47.1.32
-
-
-
-
-
-
-
-
-
+# To confirm
+forge_version=1.19.4-45.1.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-org.gradle.jvmargs=-Xmx2048M
+org.gradle.jvmargs=-Xmx4096M
 
 mod_id=experienced_crops
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,25 +2,24 @@ org.gradle.jvmargs=-Xmx2048M
 
 mod_id=experienced_crops
 
-minecraft_version=1.19.2
+minecraft_version=1.20.1
 enabled_platforms=fabric,forge
 
-mod_version=1.19.2-1.0.0
+mod_version=1.20.1-1.1.0
 maven_group=com.ordana.experienced_crops
 
-parchment_version = 1.19.2:2022.08.10
-quilt_version = 1.18.2+build.24:v2
+parchment_version = 1.20.1:2023.07.09
+quilt_version = 0.20.0-beta.4
 
-fabric_loader_version=0.14.9
-fabric_api_version=0.60.0+1.19.2
+fabric_loader_version=0.14.22
+fabric_api_version=0.86.0+1.20.1
 
-forge_version=1.19.2-43.1.30
+forge_version=1.20.1-47.1.32
 
 modmenu_version = 4.0.0
 cloth_version = 7.0.72
 
-
-moonlight_version = 1.19.2-2.1.4
+moonlight_version = 1.20-2.7.0
 
 
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ mod_id=experienced_crops
 minecraft_version=1.20.1
 enabled_platforms=fabric,forge
 
-mod_version=1.20.1-1.1.0
+mod_version=1.20.1-1.1.1
 maven_group=com.ordana.experienced_crops
 
 parchment_version = 1.20.1:2023.07.09
@@ -15,11 +15,6 @@ fabric_loader_version=0.14.22
 fabric_api_version=0.86.0+1.20.1
 
 forge_version=1.20.1-47.1.32
-
-modmenu_version = 4.0.0
-cloth_version = 7.0.72
-
-moonlight_version = 1.20-2.7.0
 
 
 


### PR DESCRIPTION
Backported 1.1.1 to Minecraft 1.19.4
No change in the actual code were required, it was just a matter of updating dependencies.

Tested on Forge, Fabric, and Quilt clients. However I'm only really familiar with fabric. ~~I'm not sure on how I was supposed to handle Quilt; I still had to install the fabric-api jar, which sound a bit odd to me.~~